### PR TITLE
Fix invokeinterface when no iface argument is provided.

### DIFF
--- a/src/insn/op.clj
+++ b/src/insn/op.clj
@@ -184,7 +184,7 @@
   The last argument `iface` can be used to specify the method's owner
   class is an interface (e.g., a default implementation)."
   ([v cls mname] (&fn v cls mname -1))
-  ([v cls mname desc-or-arity] (&fn v cls mname desc-or-arity false))
+  ([v cls mname desc-or-arity] (&fn v cls mname desc-or-arity (= &op Opcodes/INVOKEINTERFACE)))
   ([v cls mname desc-or-arity iface]
    (let [mname (util/method-name mname)
          desc (if (number? desc-or-arity)


### PR DESCRIPTION
For version 0.5.3, https://github.com/jgpc42/insn/commit/d95a5837c474476e908c39222dd8ef6dcb200093 exposed the interface arg to method instructions. When no interface arg is provided, the interface arg always defaults to false. If you look at the [implementation for visitMethodInsn](https://github.com/consulo/objectweb-asm/blob/master/asm/src/main/java/org/objectweb/asm/MethodVisitor.java#L410), the default should be false **except** for the invoke interface opcode. Passing `false` when the opcode is invoke interface can lead to invalid constant pool exception as seen in this issue, https://github.com/jgpc42/insn/issues/12. 